### PR TITLE
feat: add exclude private functions and methods

### DIFF
--- a/pydoctest/configuration.py
+++ b/pydoctest/configuration.py
@@ -49,6 +49,12 @@ class Configuration():
         # Throw an error if 'raises' section does not list all exceptions
         self.fail_on_raises_section = True
 
+        # Exclude private functions that start with underscore
+        self.exclude_private_functions = False
+
+        # Exclude private class methods that start with underscore
+        self.exclude_private_methods = False
+
     @staticmethod
     def get_default_configuration(root_dir: Optional[str] = None) -> 'Configuration':
         """Returns a configuration with default values.

--- a/pydoctest/main.py
+++ b/pydoctest/main.py
@@ -128,7 +128,10 @@ class PyDoctestService():
         """
         fns = []
         for name, obj in inspect.getmembers(module, lambda x: inspect.isfunction(x) and x.__module__ == module.__name__):
-            fns.append(obj)
+            if self.config.exclude_private_functions and name.startswith("_"):
+                pass
+            else:
+                fns.append(obj)
         return fns
 
     def get_classes(self, module: ModuleType) -> List[Type]:

--- a/pydoctest/validation.py
+++ b/pydoctest/validation.py
@@ -367,6 +367,8 @@ def validate_class(class_instance: Any, config: Configuration, module_type: Modu
         if inspect.isfunction(item) and item.__module__ == module_type.__name__:
             if name not in class_instance.__dict__ or item != class_instance.__dict__[name]:
                 continue
+            if config.exclude_private_methods and name.startswith("_"):
+                continue
             function_result = validate_function(item, config, module_type)
             if function_result.result == ResultType.FAILED:
                 class_result.result = ResultType.FAILED


### PR DESCRIPTION
I added the functionality in the `get_global_functions` function by excluding functions with names that start with _.

This can later be expanded into more generic exclusion patterns.